### PR TITLE
Add endpoint#basic_auth?

### DIFF
--- a/lib/oas_parser/endpoint.rb
+++ b/lib/oas_parser/endpoint.rb
@@ -96,6 +96,16 @@ module OasParser
       false
     end
 
+    def basic_auth?
+      return false unless security
+
+      security_schemes.each do |security_schema|
+        return true if security_schema['type'] == 'http' && security_schema['scheme'] == 'basic'
+      end
+
+      false
+    end
+
     def security_schemes
       security_schemes = security.flat_map(&:keys)
 

--- a/lib/oas_parser/version.rb
+++ b/lib/oas_parser/version.rb
@@ -1,3 +1,3 @@
 module OasParser
-  VERSION = '0.11.0'.freeze
+  VERSION = '0.11.1'.freeze
 end

--- a/spec/oas_parser/endpoint_spec.rb
+++ b/spec/oas_parser/endpoint_spec.rb
@@ -120,6 +120,36 @@ RSpec.describe OasParser::Endpoint do
     end
   end
 
+  describe '#basic_auth?' do
+    it 'returns a boolean indicating if the endpoint uses Basic Auth authentication' do
+      expect(@endpoint.basic_auth?).to eq(false)
+    end
+
+    context 'when the definition provides a security scheme with JWT' do
+      before do
+        allow(@definition).to receive(:components) { { 'securitySchemes' => { 'foo' => { 'type' => 'http', 'scheme' => 'basic' } } } }
+      end
+
+      it 'returns false when the definition does not subscribe to the security scheme' do
+        expect(@endpoint.basic_auth?).to eq(false)
+      end
+
+      context 'definition subscribes to the securitys scheme' do
+        it 'returns true' do
+          allow(@definition).to receive(:security) { [{ 'foo' => [] }] }
+          expect(@endpoint.basic_auth?).to eq(true)
+        end
+      end
+
+      context 'endpoint subscribes to the securitys scheme' do
+        it 'returns true' do
+          allow(@endpoint).to receive(:security) { [{ 'foo' => [] }] }
+          expect(@endpoint.basic_auth?).to eq(true)
+        end
+      end
+    end
+  end
+
   describe '#security_schemes' do
     it 'returns a boolean indicating if the endpoint uses JWT authentication' do
       expect(@endpoint.security_schemes).to eq([])

--- a/spec/oas_parser/endpoint_spec.rb
+++ b/spec/oas_parser/endpoint_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe OasParser::Endpoint do
       expect(@endpoint.basic_auth?).to eq(false)
     end
 
-    context 'when the definition provides a security scheme with JWT' do
+    context 'when the definition provides a security scheme that is BasicAuth' do
       before do
         allow(@definition).to receive(:components) { { 'securitySchemes' => { 'foo' => { 'type' => 'http', 'scheme' => 'basic' } } } }
       end


### PR DESCRIPTION
Adds `basic_auth?` method onto endpoint. Returns a boolean indicating if the endpoint subscribes to a basic auth security schema.