### PR TITLE
Relax activesupport

### DIFF
--- a/oas_parser.gemspec
+++ b/oas_parser.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json_schema", "~> 0.15.0"
   spec.add_dependency "guard-rspec", "~> 4.7.3"
   spec.add_dependency "deep_merge", "~> 1.2.1"
-  spec.add_dependency "activesupport", "~> 5.1.2"
+  spec.add_dependency "activesupport", "< 6"
   spec.add_dependency "builder", "~> 3.2.3"
   spec.add_dependency "nokogiri", "~> 1.8.1"
 


### PR DESCRIPTION
Rails 5.2 is last major release as rails/master development is now targeting Rails 6.0.