### PR TITLE
initialize instance variable

### DIFF
--- a/lib/oas_parser/abstract_attribute.rb
+++ b/lib/oas_parser/abstract_attribute.rb
@@ -2,6 +2,10 @@ module OasParser
   class AbstractAttribute
     include OasParser::RawAccessor
 
+    def initialize(name)
+      @name = name
+    end
+
     def name(format = nil)
       default = @name || raw['name']
       return default unless format

--- a/lib/oas_parser/parameter.rb
+++ b/lib/oas_parser/parameter.rb
@@ -6,6 +6,7 @@ module OasParser
     attr_accessor :owner, :raw
 
     def initialize(owner, raw)
+      super(raw['name'])
       @owner = owner
       @raw = raw
     end

--- a/lib/oas_parser/property.rb
+++ b/lib/oas_parser/property.rb
@@ -7,8 +7,8 @@ module OasParser
     attr_writer :name
 
     def initialize(owner, schema, name, raw)
+      super(name)
       @owner = owner
-      @name = name
       @schema = schema
       @raw = raw
     end


### PR DESCRIPTION
When we execute this code with -w option, we got warning.
Parameter object not set @name so we should initialize @name.

```ruby
require 'oas_parser'

d = OasParser::Definition.resolve("./spec/fixtures/petstore-expanded.yml")
path = d.path_by_path('/pets')
endpoint = path.endpoint_by_method('get')
endpoint.query_parameters.map{ |param| param.name }
```

```
ruby -w test.rb
/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/oas_parser-0.14.0/lib/oas_parser/abstract_attribute.rb:6: warning: instance variable @name not initialized
/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/oas_parser-0.14.0/lib/oas_parser/abstract_attribute.rb:6: warning: instance variable @name not initialized
```