### PR TITLE
Move guard-rspec to development dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,12 @@ PATH
       addressable (~> 2.3)
       builder (~> 3.2.3)
       deep_merge (~> 1.2.1)
-      guard-rspec (~> 4.7.3)
       nokogiri (~> 1.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -21,7 +20,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     deep_merge (1.2.1)
     diff-lcs (1.3)
     docile (1.1.5)
@@ -41,7 +40,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    i18n (1.1.1)
+    i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.1.5)
@@ -98,6 +97,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  guard-rspec (~> 4.7.3)
   oas_parser!
   pry (~> 0.11.3)
   rake (~> 10.0)
@@ -106,4 +106,4 @@ DEPENDENCIES
   simplecov (~> 0.15.1)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/oas_parser.gemspec
+++ b/oas_parser.gemspec
@@ -21,13 +21,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "guard-rspec", "~> 4.7.3"
   spec.add_dependency "deep_merge", "~> 1.2.1"
   spec.add_dependency "activesupport", "> 5.1.2", "< 6"
   spec.add_dependency "builder", "~> 3.2.3"
   spec.add_dependency "nokogiri", "~> 1.8.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "guard-rspec", "~> 4.7.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-collection_matchers", "~> 1.1.3"


### PR DESCRIPTION
guard has quite a few dependencies which don't have to get installed if using oas_parser in production.