### PR TITLE
[Nexmo/oas_parser#20] alternative implementation for resolving remote…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # rspec failure tracking
 .rspec_status
+.ruby-gemset
+.ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     oas_parser (0.15.2)
-      activesupport (> 5.1.2, < 6)
+      activesupport (>= 4.0.0)
       addressable (~> 2.3)
       builder (~> 3.2.3)
       deep_merge (~> 1.2.1)
       mustermann-contrib (~> 1.0.3s)
-      nokogiri (~> 1.8.1)
+      nokogiri
 
 GEM
   remote: https://rubygems.org/

--- a/oas_parser.gemspec
+++ b/oas_parser.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.3"
   spec.add_dependency "deep_merge", "~> 1.2.1"
-  spec.add_dependency "activesupport", "> 5.1.2", "< 6"
+  spec.add_dependency "activesupport", ">= 4.0.0"
   spec.add_dependency "builder", "~> 3.2.3"
   spec.add_dependency "mustermann-contrib", "~> 1.0.3s"
-  spec.add_dependency "nokogiri", "~> 1.8.1"
+  spec.add_dependency "nokogiri"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "guard-rspec", "~> 4.7.3"

--- a/spec/fixtures/petstore-remote-reference-components.yml
+++ b/spec/fixtures/petstore-remote-reference-components.yml
@@ -1,0 +1,31 @@
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string              

--- a/spec/fixtures/petstore-remote-reference-pets.yml
+++ b/spec/fixtures/petstore-remote-reference-pets.yml
@@ -1,0 +1,62 @@
+get:
+  description: |
+    Returns all pets from the system that the user has access to
+    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+  operationId: findPets
+  parameters:
+    - name: tags
+      in: query
+      description: tags to filter by
+      required: false
+      style: form
+      schema:
+        type: array
+        items:
+          type: string
+    - name: limit
+      in: query
+      description: maximum number of results to return
+      required: false
+      schema:
+        type: integer
+        format: int32
+  responses:
+    '200':
+      description: pet response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: './petstore-remote-reference-components.yml#/components/schemas/Pet'
+    default:
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: './petstore-remote-reference-components.yml#/components/schemas/Error'
+post:
+  description: Creates a new pet in the store.  Duplicates are allowed
+  operationId: addPet
+  requestBody:
+    description: Pet to add to the store
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './petstore-remote-reference-components.yml#/components/schemas/NewPet'
+  responses:
+    '200':
+      description: pet response
+      content:
+        application/json:
+          schema:
+            $ref: './petstore-remote-reference-components.yml#/components/schemas/Pet'
+    default:
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: './petstore-remote-reference-components.yml#/components/schemas/Error'

--- a/spec/fixtures/petstore-remote-reference.yml
+++ b/spec/fixtures/petstore-remote-reference.yml
@@ -1,0 +1,66 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: http://madskristensen.net
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    $ref: './petstore-remote-reference-pets.yml'
+
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: './petstore-remote-reference-components.yml#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: './petstore-remote-reference-components.yml#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: './petstore-remote-reference-components.yml#/components/schemas/Error'
+components:
+  schemas:

--- a/spec/oas_parser/parser_spec.rb
+++ b/spec/oas_parser/parser_spec.rb
@@ -3,4 +3,14 @@ RSpec.describe OasParser::Parser do
     definition = OasParser::Parser.resolve('spec/fixtures/petstore-expanded.yml')
     expect(definition.class).to eq(Hash)
   end
+
+  it 'parses references from a definition file with external data' do
+    definition = OasParser::Parser.resolve('spec/fixtures/petstore-remote-reference.yml')
+
+    expect(definition.class).to eq(Hash)
+
+    expect(definition.dig('paths', '/pets', 'get', 'responses', '200', 
+                            'content', 'application/json', 'schema', 'items', 'allOf').map {|h| h['properties'].keys }.flatten).to eq (['name', 'tag', 'id'])
+  end
+
 end


### PR DESCRIPTION
This is an alternative implementation for issue #20 which will work for both a whole document remote reference

`$ref: 'document.json'`

and for local references contained within a remote reference

`$ref: 'document.json#/myElement'`

Additional notes about changes included in this PR:

* There is no support for URL references, an error will be raised if found
* There are likely more edge cases supported by the parser, but only a moderately complex version was tested. 
* In addition to the unit test, I've also test with ReDoc
* The version dependencies for `nokogiri` and `activesupport` have been relaxed because it is best practice to require the minimum version for functionality to work. 