### PR TITLE
Add parameter to fall back to "default" response

### DIFF
--- a/lib/oas_parser/endpoint.rb
+++ b/lib/oas_parser/endpoint.rb
@@ -63,8 +63,9 @@ module OasParser
       end
     end
 
-    def response_by_code(code)
+    def response_by_code(code, use_default: false)
       definition = raw['responses'][code]
+      definition ||= raw['responses']['default'] if use_default
       raise OasParser::ResponseCodeNotFound.new("Response code not found: '#{code}'") unless definition
       OasParser::Response.new(self, code, definition)
     end

--- a/spec/oas_parser/endpoint_spec.rb
+++ b/spec/oas_parser/endpoint_spec.rb
@@ -196,7 +196,22 @@ RSpec.describe OasParser::Endpoint do
       expect(@endpoint.response_by_code('200').class).to eq(OasParser::Response)
     end
 
-    context 'when given an invalid method' do
+    context 'use default' do
+      it 'returns the "default" response if no matching response was found' do
+        response = @endpoint.response_by_code('422', use_default: true)
+        expect(response.class).to eq(OasParser::Response)
+        expect(response.code).to eq('422')
+        expect(response.description).to eq('unexpected error')
+      end
+
+      it 'returns the matching response' do
+        response = @endpoint.response_by_code('200', use_default: true)
+        expect(response.class).to eq(OasParser::Response)
+        expect(response.code).to eq('200')
+      end
+    end
+
+    context 'when given an unknown status' do
       it 'raises an exception' do
         expect {
           @endpoint.response_by_code('foo')


### PR DESCRIPTION
Calling `Endpoint#response_by_code('422', use_default: true)`
returns the "default" response if it was defined in the spec. `use_default` is `false` by default.

See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-14 for a description about "default" responses.