### PR TITLE
Return template path when calling path path_by_path

### DIFF
--- a/lib/oas_parser/definition.rb
+++ b/lib/oas_parser/definition.rb
@@ -29,14 +29,15 @@ module OasParser
     end
 
     def path_by_path(path)
-      definition = raw['paths'].fetch(path) do |path|
-        key = raw['paths'].keys.detect do |path_entry|
-          Mustermann::Template.new(path_entry).match(path)
-        end
-        raw['paths'][key]
+      definition = raw['paths'][path]
+      return OasParser::Path.new(self, path, definition) if definition
+
+      key = raw['paths'].keys.detect do |path_entry|
+        Mustermann::Template.new(path_entry).match(path)
       end
+      definition = raw['paths'][key]
       raise OasParser::PathNotFound.new("Path not found: '#{path}'") unless definition
-      OasParser::Path.new(self, path, definition)
+      OasParser::Path.new(self, key, definition)
     end
 
     def security

--- a/spec/oas_parser/definition_spec.rb
+++ b/spec/oas_parser/definition_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe OasParser::Definition do
     end
 
     it 'finds a path template by path' do
-      expect(@definition.path_by_path('/pets/1').class).to eq(OasParser::Path)
+      path = @definition.path_by_path('/pets/1')
+      expect(path.class).to eq(OasParser::Path)
+      expect(path.path).to eq('/pets/{id}')
     end
 
     context 'when given an invalid path' do


### PR DESCRIPTION
```ruby
definition.path_by_path('/pets/1').path # => now returns '/pets/{id}' instead of '/pets/1'
```

This is good, because `Defition#path_by_path` now behaves just like `Definition#paths[…].path`.

I need this behaviour, because I would like to know exactly what part of the spec `GET /pets/1` is
referring to.