### PR TITLE
Remove activesupport

### DIFF
--- a/lib/oas_parser.rb
+++ b/lib/oas_parser.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'uri'
 require 'yaml'
-require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/conversions'
 require 'nokogiri'
 

--- a/lib/oas_parser/abstract_attribute.rb
+++ b/lib/oas_parser/abstract_attribute.rb
@@ -38,8 +38,8 @@ module OasParser
 
     def empty?
       raise 'Called empty? on non collection type' unless collection?
-      return true if object? && raw['properties'].blank?
-      return true if array? && items.blank?
+      return true if object? && raw['properties']&.empty?
+      return true if array? && items&.empty?
       false
     end
 
@@ -53,7 +53,7 @@ module OasParser
     end
 
     def has_xml_options?
-      raw['xml'].present?
+      raw['xml'].any?
     end
 
     def is_xml_attribute?
@@ -79,7 +79,7 @@ module OasParser
 
     def subproperties_are_one_of_many?
       return false unless array?
-      items['oneOf'].present?
+      items['oneOf'].any?
     end
   end
 end

--- a/lib/oas_parser/endpoint.rb
+++ b/lib/oas_parser/endpoint.rb
@@ -29,7 +29,7 @@ module OasParser
 
     def security_schema_parameters
       raw_security_schema_parameters = security_schemes.select do |security_schema|
-        security_schema['in'].present? && security_schema['in'].present?
+        !security_schema['in'].empty? && !security_schema['in'].empty?
       end
 
       security_schema_parameter_defaults = {

--- a/lib/oas_parser/response_parser.rb
+++ b/lib/oas_parser/response_parser.rb
@@ -188,7 +188,7 @@ module OasParser
     end
 
     def has_xml_options?(object)
-      object['xml'].present?
+      object['xml']&.any?
     end
 
     def is_xml_attribute?(object)

--- a/lib/oas_parser/version.rb
+++ b/lib/oas_parser/version.rb
@@ -1,3 +1,3 @@
 module OasParser
-  VERSION = '0.17.0'.freeze
+  VERSION = '0.16.0'.freeze
 end


### PR DESCRIPTION
ActiveSupport is great, but maybe we can remove it without a huge impact on redability…
This PR is not that important.

- [x] Don't rely on core_ext/hash/blank (`blank?`, `present?`)
- [ ] Don't rely on core_ext/hash/conversions (`to_xml`) 🤷‍♂️ 