### PR TITLE
Handle circular references when resolving

### DIFF
--- a/lib/oas_parser/CHANGELOG.md
+++ b/lib/oas_parser/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Unreleased
+
+- Parser now handles circular/self reference by returning the $ref as is instead of expanding it indefinitely. (Qihuan Piao)

--- a/lib/oas_parser/parser.rb
+++ b/lib/oas_parser/parser.rb
@@ -31,18 +31,18 @@ module OasParser
     end
 
     def expand_refs(fragment, current_path)
-      if fragment.is_a?(Hash) && fragment.key?("$ref")
-        ref = fragment["$ref"]
+      unless fragment.is_a?(Hash) && fragment.key?("$ref")
+        return [fragment, current_path]
+      end
 
-        if ref =~ /^#/
-          expand_pointer(ref, current_path)
-        elsif ref =~ /^(http(s)?|\/\/)/
-          expand_url(ref)
-        else
-          expand_file(ref)
-        end
+      ref = fragment["$ref"]
+
+      if ref =~ /^#/
+        expand_pointer(ref, current_path)
+      elsif ref =~ /^(http(s)?|\/\/)/
+        expand_url(ref)
       else
-        [fragment, current_path]
+        expand_file(ref)
       end
     end
 

--- a/lib/oas_parser/pointer.rb
+++ b/lib/oas_parser/pointer.rb
@@ -12,7 +12,28 @@ module OasParser
       end
     end
 
-    private
+    # Detect circular reference by checking whether the ref exists in current path.
+    #
+    # Example:
+    # components:
+    #   schemas:
+    #     Pet:
+    #       type: object
+    #       properties:
+    #         name:
+    #           type: string
+    #         children:
+    #           type: array
+    #           items: # <--- parsing here
+    #             - $ref: '#/components/schemas/Pet'
+    #
+    # path: "/components/schemas/Pet/properties/children/items"
+    # raw_pointer: "#/components/schemas/Pet"
+    #
+    # It'd return true when we're parsing the pet children items where the ref points back to itself.
+    def circular_reference?(path)
+      path.include?("#{escaped_pointer}/")
+    end
 
     def escaped_pointer
       if @raw_pointer.start_with?("#")
@@ -21,6 +42,8 @@ module OasParser
         @raw_pointer
       end
     end
+
+    private
 
     def parse_token(token)
       if token =~ /\A\d+\z/

--- a/lib/oas_parser/version.rb
+++ b/lib/oas_parser/version.rb
@@ -1,3 +1,3 @@
 module OasParser
-  VERSION = '0.18.2'.freeze
+  VERSION = '0.19.0'.freeze
 end

--- a/spec/fixtures/petstore-recursive.yml
+++ b/spec/fixtures/petstore-recursive.yml
@@ -1,0 +1,47 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: http://madskristensen.net
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /owners:
+    get:
+      description: Get an owner
+      operationId: findPets
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Human:
+      type: object
+      properties:
+        name:
+          type: string
+        pets:
+          type: array
+          items:
+            - $ref: '#/components/schemas/Pet'
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        owners:
+          type: array
+          items:
+            - $ref: '#/components/schemas/Human'

--- a/spec/fixtures/petstore-self-referential.yml
+++ b/spec/fixtures/petstore-self-referential.yml
@@ -1,0 +1,38 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: http://madskristensen.net
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pet:
+    get:
+      description: Get pet
+      operationId: findPets
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        children:
+          type: array
+          items:
+            - $ref: '#/components/schemas/Pet'

--- a/spec/oas_parser/parser_spec.rb
+++ b/spec/oas_parser/parser_spec.rb
@@ -15,8 +15,21 @@ RSpec.describe OasParser::Parser do
 
     expect(definition.class).to eq(Hash)
 
-    expect(definition.dig('paths', '/pets', 'get', 'responses', '200', 
+    expect(definition.dig('paths', '/pets', 'get', 'responses', '200',
                             'content', 'application/json', 'schema', 'items', 'allOf').map {|h| h['properties'].keys }.flatten).to eq (['name', 'tag', 'id'])
   end
 
+  it 'parses references and stops expanding them if they are circular references' do
+    definition = OasParser::Parser.resolve('spec/fixtures/petstore-recursive.yml')
+    pets_owners = definition.dig('components', 'schemas', 'Human', 'properties', 'pets', 'items', 0, 'properties', 'owners')
+
+    expect(pets_owners['items']).to eq([{ '$ref' => '#/components/schemas/Human' }])
+  end
+
+  it 'parses references and stops expanding them if they are self referential' do
+    definition = OasParser::Parser.resolve('spec/fixtures/petstore-self-referential.yml')
+    pet_children = definition.dig('components', 'schemas', 'Pet', 'properties', 'children', 'items')
+
+    expect(pet_children).to eq([{ '$ref' => '#/components/schemas/Pet' }])
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/Nexmo/oas_parser/issues/24, also another implementation of #25 

## Overview

Parser now handles circular/self reference by returning the $ref as is instead of expanding it indefinitely.

## Background

Historically, my colleague @ssteeg-mdsol had sent a Pull Request (https://github.com/braintree/open_api_parser/pull/10) to [open_api_parser](https://github.com/braintree/open_api_parser) to handle the exact same circular references. We had been using it in our various projects ever since and had no problem.

We found this gem when we migrate to OpenAPI V3. Later I also found out that this project was originated from `open_api_parser`, the codebase shares the similarity which makes applying the same patch super easy. So the changes here are almost identical to https://github.com/braintree/open_api_parser/pull/10.

## Notes for Reviewers

I added a changelog as I think it'd be helpful for developers to understand the notable changes between each release. I didn't back-filled the old releases. (Please feel free to modify / amend 🙏 )

As for how the circular reference should be handled, I couldn't find a universally agreed upon answer. right now I'm keeping it as is. The code is flexible to adopt to other strategies like removing it entirely. Probably in the future, if we see the needs we could add `OasParser.circule_reference_strategy = :removal` or `:nullify` and let the users decide which way to go. But for now, think that'd be an overkill 🙂.

cc @ssteeg-mdsol @ykitamura-mdsol @jfeltesse-mdsol