### PR TITLE
Add support for allOf in OasParser::Property

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,19 +6,21 @@ PATH
       addressable (~> 2.3)
       builder (~> 3.2.3)
       deep_merge (~> 1.2.1)
+      hash-deep-merge
       mustermann-contrib (~> 1.0.3s)
       nokogiri
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+      zeitwerk (~> 2.1, >= 2.1.8)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -42,6 +44,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hansi (0.2.0)
+    hash-deep-merge (0.1.1)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
@@ -58,7 +61,7 @@ GEM
       hansi (~> 0.2.0)
       mustermann (= 1.0.3)
     nenv (0.3.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -66,7 +69,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.3)
+    public_suffix (4.0.1)
     rake (10.5.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -97,6 +100,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    zeitwerk (2.1.9)
 
 PLATFORMS
   ruby

--- a/lib/oas_parser/abstract_attribute.rb
+++ b/lib/oas_parser/abstract_attribute.rb
@@ -20,6 +20,10 @@ module OasParser
       raw['enum'] || (schema ? schema['enum'] : nil)
     end
 
+    def allOf?
+      raw['allOf'] ? true : false
+    end
+
     def oneOf?
       raw['oneOf'] ? true : false
     end
@@ -44,7 +48,7 @@ module OasParser
     end
 
     def properties
-      return convert_property_schema_to_properties(raw) if oneOf?
+      return convert_property_schema_to_properties(raw) if (oneOf? || allOf?)
       return nil unless collection?
       return [] if empty?
       return convert_property_schema_to_properties(raw['properties']) if object?

--- a/lib/oas_parser/property.rb
+++ b/lib/oas_parser/property.rb
@@ -20,6 +20,14 @@ module OasParser
     end
 
     def convert_property_schema_to_properties(schema)
+      if schema['allOf']
+        schema['properties'] = {}
+        schema['allOf'].each do |p|
+          schema['properties'].deep_merge!(p['properties'])
+        end
+        schema.delete('allOf')
+      end
+
       if schema['oneOf']
         schema['oneOf'].map do |subschema|
           subschema['properties'] = convert_property_schema_to_properties(subschema)

--- a/oas_parser.gemspec
+++ b/oas_parser.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "builder", "~> 3.2.3"
   spec.add_dependency "mustermann-contrib", "~> 1.0.3s"
   spec.add_dependency "nokogiri"
+  spec.add_dependency "hash-deep-merge"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "guard-rspec", "~> 4.7.3"

--- a/spec/fixtures/petstore-parameter-oneof-allof.yml
+++ b/spec/fixtures/petstore-parameter-oneof-allof.yml
@@ -1,0 +1,64 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                details:
+                  oneOf:
+                    - $ref: "#/components/schemas/RealName"
+                    - $ref: "#/components/schemas/NickName"
+
+      responses:
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                properties:
+                  done:
+                    type: string
+                    example: "Done"
+components:
+  schemas:
+    Age:
+      type: object
+      properties:
+        age:
+          type: integer
+          example: 12
+          description: How old's your dog?
+    RealName:
+      allOf:
+        - $ref: "#/components/schemas/Age"
+        - type: object
+          properties:
+            realname:
+              type: string
+              example: Fido
+              description: What's your dog's real name?
+    NickName:
+      allOf:
+        - $ref: "#/components/schemas/Age"
+        - type: object
+          properties:
+            nickname:
+              type: string
+              example: SillyDog
+              description: What do you call your dog when it's being silly?

--- a/spec/oas_parser/oneof_allof_spec.rb
+++ b/spec/oas_parser/oneof_allof_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe OasParser::Parameter do
+  before do
+    @definition = OasParser::Definition.resolve('spec/fixtures/petstore-parameter-oneof-allof.yml')
+    @path = @definition.path_by_path('/pets')
+    @endpoint = @path.endpoint_by_method('post')
+    @request_body = @endpoint.request_body
+    @property = @request_body.properties_for_format('application/json')[0]
+  end
+
+  describe '#name' do
+    it 'returns the parameter name' do
+      expect(@property.name).to eq('details')
+    end
+
+    it 'returns all possible parameter definitions' do
+      expect(@property.properties).to have(2).items
+    end
+
+    it 'returns items in the defined order' do
+      # The first oneOf details option is age + realname
+      expect(@property.properties[0]['properties'][0].name).to eq('age')
+      expect(@property.properties[0]['properties'][1].name).to eq('realname')
+
+      # The second oneOf details option is age + nickname
+      expect(@property.properties[1]['properties'][0].name).to eq('age')
+      expect(@property.properties[1]['properties'][1].name).to eq('nickname')
+    end
+
+    it 'provides a complete "property" object' do
+      age = @property.properties[0]['properties'][0]
+      expect(age.name).to eq('age')
+      expect(age.example).to eq(12)
+      expect(age.description).to eq("How old's your dog?")
+    end
+  end
+end


### PR DESCRIPTION
This PR deep merges all keys in a property when it encounters `allOf` in a spec. This allows us to use `allOf` contained within a `oneOf`