### PR TITLE
Keys should always be strings, not scalars

### DIFF
--- a/lib/oas_parser/pointer.rb
+++ b/lib/oas_parser/pointer.rb
@@ -46,11 +46,7 @@ module OasParser
     private
 
     def parse_token(token)
-      if token =~ /\A\d+\z/
-        token.to_i
-      else
-        token.gsub("~0", "~").gsub("~1", "/")
-      end
+      token.gsub("~0", "~").gsub("~1", "/")
     end
 
     def tokens

--- a/lib/oas_parser/version.rb
+++ b/lib/oas_parser/version.rb
@@ -1,3 +1,3 @@
 module OasParser
-  VERSION = '0.22.4'.freeze
+  VERSION = '0.23.0'.freeze
 end


### PR DESCRIPTION
This ensures interoperability between JSON and YAML formats and is in
the spec