### PR TITLE
Fix musterman-contrib version, update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,13 @@ PATH
       builder (~> 3.2.3)
       deep_merge (~> 1.2.1)
       hash-deep-merge
-      mustermann-contrib (~> 1.0.3s)
+      mustermann-contrib (~> 1.1.1)
       nokogiri
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.1)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -45,7 +45,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hansi (0.2.0)
     hash-deep-merge (0.1.1)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.1.5)
@@ -55,11 +55,12 @@ GEM
     lumberjack (1.0.13)
     method_source (0.9.2)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
-    mustermann (1.0.3)
-    mustermann-contrib (1.0.3)
+    minitest (5.14.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    mustermann-contrib (1.1.1)
       hansi (~> 0.2.0)
-      mustermann (= 1.0.3)
+      mustermann (= 1.1.1)
     nenv (0.3.0)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -69,7 +70,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     rake (10.5.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -89,6 +90,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     shellany (0.0.1)
     simplecov (0.15.1)
@@ -98,7 +100,7 @@ GEM
     simplecov-html (0.10.2)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     zeitwerk (2.2.2)
 
@@ -106,7 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.1)
   guard-rspec (~> 4.7.3)
   oas_parser!
   pry (~> 0.11.3)
@@ -116,4 +118,4 @@ DEPENDENCIES
   simplecov (~> 0.15.1)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/oas_parser.gemspec
+++ b/oas_parser.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deep_merge", "~> 1.2.1"
   spec.add_dependency "activesupport", ">= 4.0.0"
   spec.add_dependency "builder", "~> 3.2.3"
-  spec.add_dependency "mustermann-contrib", "~> 1.0.3s"
+  spec.add_dependency "mustermann-contrib", "~> 1.1.1"
   spec.add_dependency "nokogiri"
   spec.add_dependency "hash-deep-merge"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "guard-rspec", "~> 4.7.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
There seemed to be a typo in the musterman-contrib version. This fixes that and updates to the latest version.