### PR TITLE
Add support for OAS 3.1 compatible webhooks

### DIFF
--- a/lib/oas_parser/definition.rb
+++ b/lib/oas_parser/definition.rb
@@ -47,5 +47,12 @@ module OasParser
     def endpoints
       paths.flat_map(&:endpoints)
     end
+
+    def webhooks
+      return [] unless raw['webhooks']
+      raw['webhooks'].map do |name, definition|
+        OasParser::Webhook.new(self, name, definition)
+      end
+    end
   end
 end

--- a/lib/oas_parser/webhook.rb
+++ b/lib/oas_parser/webhook.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module OasParser
+  class Webhook < Path
+    def name
+      path
+    end
+  end
+end

--- a/spec/fixtures/petstore-webhooks.yml
+++ b/spec/fixtures/petstore-webhooks.yml
@@ -1,0 +1,59 @@
+openapi: 3.1.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+paths:
+  # OpenAPI documents all need a paths element
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"

--- a/spec/oas_parser/definition_spec.rb
+++ b/spec/oas_parser/definition_spec.rb
@@ -76,4 +76,14 @@ RSpec.describe OasParser::Definition do
       end
     end
   end
+
+  describe '#webhooks' do
+    it 'handles specs with no webhooks' do
+      expect(@definition.webhooks.count).to eq(0)
+    end
+    it 'returns a list of webhooks' do
+      definition = OasParser::Definition.resolve('spec/fixtures/petstore-webhooks.yml')
+      expect(definition.webhooks[0].class).to eq(OasParser::Webhook)
+    end
+  end
 end

--- a/spec/oas_parser/webhook_spec.rb
+++ b/spec/oas_parser/webhook_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe OasParser::Webhook do
+  before do
+    @definition = OasParser::Definition.resolve('spec/fixtures/petstore-webhooks.yml')
+    @webhook = @definition.webhooks[0]
+  end
+
+  describe '#name' do
+    it 'returns the webhook name' do
+      expect(@webhook.name).to eq('newPet')
+    end
+  end
+
+  describe '#definition' do
+    it 'returns the parent definition' do
+      expect(@webhook.definition).to eq(@definition)
+    end
+  end
+
+  describe '#path' do
+    it 'returns the name when path is called' do
+      expect(@webhook.path).to eq('newPet')
+    end
+  end
+
+  describe '#endpoints' do
+    it 'returns the spec endpoints' do
+      expect(@webhook.endpoints.count).to eq(1)
+    end
+
+    it 'ignores keys that are not methods' do
+      allow(@webhook).to receive(:raw) { { 'get' => {}, 'post' => {}, 'parameters' => [{}] } }
+      expect(@webhook.endpoints.count).to eq(2)
+    end
+  end
+
+  describe '#parameter_keys' do
+    it 'ignores keys that are not methods' do
+      allow(@webhook).to receive(:path) { '/pets/{category}/{subcategory}' }
+      expect(@webhook.parameter_keys).to eq(%w[category subcategory])
+    end
+  end
+
+  describe '#parameters' do
+    it 'returns the path parameters' do
+      allow(@webhook).to receive(:raw) { { 'get' => {}, 'post' => {}, 'parameters' => [{}] } }
+      expect(@webhook.parameters.count).to eq(1)
+      expect(@webhook.parameters[0].class).to eq(OasParser::Parameter)
+    end
+  end
+
+  describe '#endpoint_by_method' do
+    it 'allows for an endpoint to be retrived by its method' do
+      expect(@webhook.endpoint_by_method('post').class).to eq(OasParser::Endpoint)
+    end
+
+    context 'when given an invalid method' do
+      it 'raises an exception' do
+        expect do
+          @webhook.endpoint_by_method('foo')
+        end.to raise_error(OasParser::MethodNotFound, "HTTP method not found: 'foo'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
OAS 3.1 adds a new `webhooks` section at the top level that is identical to
`paths`, with the caveat that instead of a `/path` we have a `webhook-name`.
The objects contained within are standard `Path Item` objects

This commit adds `#webhooks` to the `Definition` class to return a list
of webhooks. This list contains `Webhook` objects that inherit from
`Path` and add a single new method, `#name` which calls `#path`
internally

Official example: https://github.com/OAI/OpenAPI-Specification/blob/v3.1.0-dev/examples/v3.1/webhook-example.yaml

Official docs: https://github.com/OAI/OpenAPI-Specification/blob/v3.1.0-dev/versions/3.1.0.md#fixed-fields