### PR TITLE
Load 'path' explicitly, because 'webhook' needs it

### DIFF
--- a/lib/oas_parser.rb
+++ b/lib/oas_parser.rb
@@ -8,6 +8,7 @@ require 'nokogiri'
 require 'addressable/uri'
 require 'deep_merge'
 
+require_relative 'oas_parser/path.rb'
 require_relative 'oas_parser/payload.rb'
 require_relative 'oas_parser/raw_accessor.rb'
 require_relative 'oas_parser/abstract_attribute.rb'


### PR DESCRIPTION
I was getting an error [uninitialized constant OasParser::Path](https://travis-ci.org/github/ahx/openapi_first/builds/676421633). This should fix that.