### PR TITLE
Fix oneOf properties in arrays

### DIFF
--- a/lib/oas_parser/property.rb
+++ b/lib/oas_parser/property.rb
@@ -30,8 +30,8 @@ module OasParser
 
       if schema['oneOf']
         schema['oneOf'].map do |subschema|
-          subschema['properties'] = convert_property_schema_to_properties(subschema)
           subschema['subschema_property'] = true
+          subschema['properties'] = convert_property_schema_to_properties(subschema)
           subschema
         end
       elsif schema['subschema_property']


### PR DESCRIPTION
When working with a `oneOf` inside an `items` entry the code was taking the wrong branch and using the full `Property` object as the key. Setting this parameter *before* recursing fixes the behaviour