### PR TITLE
Use x-webhooks if no webhooks are defined

### DIFF
--- a/lib/oas_parser/definition.rb
+++ b/lib/oas_parser/definition.rb
@@ -49,9 +49,16 @@ module OasParser
     end
 
     def webhooks
-      return [] unless raw['webhooks']
-      raw['webhooks'].map do |name, definition|
-        OasParser::Webhook.new(self, name, definition)
+      if raw['webhooks']
+        return raw['webhooks'].map do |name, definition|
+          OasParser::Webhook.new(self, name, definition)
+        end
+      elsif raw['x-webhooks']
+        return raw['x-webhooks'].map do |name, definition|
+          OasParser::Webhook.new(self, name, definition)
+        end
+      else
+        return []
       end
     end
   end

--- a/lib/oas_parser/definition.rb
+++ b/lib/oas_parser/definition.rb
@@ -52,13 +52,13 @@ module OasParser
       return [] unless raw['webhooks'] || raw['x-webhooks']
 
       if raw['webhooks']
-        return raw['webhooks'].map do |name, definition|
+        raw['webhooks'].map do |name, definition|
           OasParser::Webhook.new(self, name, definition)
         end
       end
 
       if raw['x-webhooks']
-        return raw['x-webhooks'].map do |name, definition|
+        raw['x-webhooks'].map do |name, definition|
           OasParser::Webhook.new(self, name, definition)
         end
       end

--- a/lib/oas_parser/definition.rb
+++ b/lib/oas_parser/definition.rb
@@ -49,16 +49,18 @@ module OasParser
     end
 
     def webhooks
+      return [] unless raw['webhooks'] || raw['x-webhooks']
+
       if raw['webhooks']
         return raw['webhooks'].map do |name, definition|
           OasParser::Webhook.new(self, name, definition)
         end
-      elsif raw['x-webhooks']
+      end
+
+      if raw['x-webhooks']
         return raw['x-webhooks'].map do |name, definition|
           OasParser::Webhook.new(self, name, definition)
         end
-      else
-        return []
       end
     end
   end


### PR DESCRIPTION
Bridging the gap between the RC1 "implementer's draft" of OAS 3.1 and the main release, this PR will accept `x-webhooks` as a top level element formatted as the incoming `webhooks` will be formatted (bringing it in line with other tools with experimental support such as redoc). It parses it as webhooks, and as such it will be handled by renderers and other tools in the same way.