### PR TITLE
Parse tags on root document object

### DIFF
--- a/lib/oas_parser/definition.rb
+++ b/lib/oas_parser/definition.rb
@@ -44,6 +44,10 @@ module OasParser
       raw['security'] || []
     end
 
+    def tags
+      raw['tags'] || []
+    end
+
     def endpoints
       paths.flat_map(&:endpoints)
     end

--- a/spec/fixtures/petstore-with-tags.yml
+++ b/spec/fixtures/petstore-with-tags.yml
@@ -1,0 +1,159 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: http://madskristensen.net
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+servers:
+  - url: http://petstore.swagger.io/api
+tags:
+  - name: Mammal
+  - name: Reptile
+    description: any kind of reptile
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/spec/oas_parser/definition_spec.rb
+++ b/spec/oas_parser/definition_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe OasParser::Definition do
     end
   end
 
+  describe '#tags' do
+    it 'returns an empty array when not defined' do
+      expect(@definition.tags).to eq([])
+    end
+
+    it 'returns an array of tags' do
+      definition = OasParser::Definition.resolve('spec/fixtures/petstore-with-tags.yml')
+
+      expect(definition.tags).to eq([
+        { 'name' => 'Mammal' },
+        { 'name' => 'Reptile', 'description' => 'any kind of reptile' }
+      ])
+    end
+  end
+
   describe '#path_by_path' do
     it 'allows for a path to be retrived by its path' do
       expect(@definition.path_by_path('/pets').class).to eq(OasParser::Path)

--- a/spec/oas_parser/request_body_spec.rb
+++ b/spec/oas_parser/request_body_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe OasParser::RequestBody do
 
   describe 'allOf recursive' do
     before do
-      @definition = OasParser::Definition.resolve('spec/fixtures/petstore-recursive-allOf.yml')
+      @definition = OasParser::Definition.resolve('spec/fixtures/petstore-recursive-allof.yml')
       @path = @definition.path_by_path('/pet')
       @endpoint = @path.endpoint_by_method('post')
       @request_body = @endpoint.request_body


### PR DESCRIPTION
Resolves #54.

Since, I may use this library in the future, I may add more improvements, such as a real object instead of a Hash, but until I don't need more from this (simple, but excellent) library, I would focus on my projects.

One possible improvement that could affect several parts of the library is using [OpenStruct](https://ruby-doc.org/stdlib-2.7.2/libdoc/ostruct/rdoc/OpenStruct.html) instead of Hash, so the interface is accessed always as object properties instead of hash keys. Do you have any opinion on that @mheap?

Unrelated to that, I was having an error while running the tests because the fixture file was lowercased, but the test wasn't using that convention.