### PR TITLE
Use strings as keys instead of scalars.

### DIFF
--- a/lib/oas_parser/pointer.rb
+++ b/lib/oas_parser/pointer.rb
@@ -8,7 +8,6 @@ module OasParser
       return document if escaped_pointer == ""
 
       tokens.reduce(document) do |nested_doc, token|
-        token = token.to_i if token[/^-?\d+$/]
         nested_doc.fetch(token)
       end
     end


### PR DESCRIPTION
See https://github.com/Nexmo/oas_parser/commit/2babdc1d1bc26cc20658d84983502a7fe43064dc#diff-acf5d7ecf4ff44e5cdd3c98a2cc4219a01b701eac73b8e67a510cb5bf7efaf16